### PR TITLE
Add ability to retrieving $recordsModified and optimize calls for resolver

### DIFF
--- a/src/StickinessManager.php
+++ b/src/StickinessManager.php
@@ -115,7 +115,7 @@ class StickinessManager
      */
     public function resolveRecordsModified(ConnectionInterface $connection): void
     {
-        if ($this->isRecentlyModified($connection)) {
+        if (!$this->getRecordsModified($connection) && $this->isRecentlyModified($connection)) {
             $this->setRecordsModified($connection);
         }
     }

--- a/src/StickinessManager.php
+++ b/src/StickinessManager.php
@@ -82,6 +82,22 @@ class StickinessManager
         $property->setValue($connection, $bool);
     }
 
+    /** @noinspection PhpDocMissingThrowsInspection */
+
+    /**
+     * Get DB::$recordsModified state on $connection.
+     *
+     * @param  \Illuminate\Database\ConnectionInterface $connection
+     * @return bool
+     */
+    public function getRecordsModified(ConnectionInterface $connection): bool
+    {
+        /* @noinspection PhpUnhandledExceptionInspection */
+        $property = new ReflectionProperty($connection, 'recordsModified');
+        $property->setAccessible(true);
+        return (bool)$property->getValue($connection);
+    }
+
     /**
      * Set DB::$recordsModified state to false on $connection.
      *

--- a/tests/Unit/StickinessManagerTest.php
+++ b/tests/Unit/StickinessManagerTest.php
@@ -95,6 +95,16 @@ class StickinessManagerTest extends TestCase
         $this->assertTrue($this->getRecordsModified($connection));
     }
 
+    public function testGetRecordsModified(): void
+    {
+        $connection = Mockery::mock(Connection::class);
+
+        $this->setRecordsModified($connection, true);
+
+        $manager = new StickinessManager($this->container);
+        $this->assertTrue($manager->getRecordsModified($connection));
+    }
+
     public function testSetRecordsFresh(): void
     {
         $connection = Mockery::mock(Connection::class);

--- a/tests/Unit/StickinessManagerTest.php
+++ b/tests/Unit/StickinessManagerTest.php
@@ -131,6 +131,20 @@ class StickinessManagerTest extends TestCase
         $this->assertTrue($this->getRecordsModified($connection));
     }
 
+    public function testResolveRecordsNotModified(): void
+    {
+        $connection = Mockery::mock(Connection::class);
+
+        $this->resolver->shouldNotReceive('isRecentlyModified');
+
+        $this->setRecordsModified($connection, true);
+
+        $manager = new StickinessManager($this->container);
+        $manager->resolveRecordsModified($connection);
+
+        $this->assertTrue($this->getRecordsModified($connection));
+    }
+
     public function testMarkAsModified(): void
     {
         $connection = Mockery::mock(Connection::class);


### PR DESCRIPTION
We should not call `isRecentlyModified()` if `$recordsModified` is already set to true.