### PR TITLE
Fix workers problem

### DIFF
--- a/src/JobInitializers/AlwaysFreshInitializer.php
+++ b/src/JobInitializers/AlwaysFreshInitializer.php
@@ -4,6 +4,7 @@ namespace Mpyw\LaravelCachedDatabaseStickiness\JobInitializers;
 
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Queue\Events\JobProcessing;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated;
 use Mpyw\LaravelCachedDatabaseStickiness\JobInitializers\Concerns\DetectsInterfaces;
 use Mpyw\LaravelCachedDatabaseStickiness\StickinessManager;
 
@@ -41,7 +42,7 @@ class AlwaysFreshInitializer implements JobInitializerInterface
     /**
      * {@inheritdoc}
      */
-    public function initializeStickinessState(JobProcessing $event): void
+    public function initializeOnResolvedConnections(JobProcessing $event): void
     {
         if ($this->shouldAssumeModified($event->job)) {
             foreach ($this->db->getConnections() as $connection) {
@@ -53,5 +54,15 @@ class AlwaysFreshInitializer implements JobInitializerInterface
         foreach ($this->db->getConnections() as $connection) {
             $this->stickiness->setRecordsFresh($connection);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function initializeOnNewConnection(JobProcessing $jobProcessingEvent, ConnectionCreated $connectionCreatedEvent): void
+    {
+        $this->shouldAssumeModified($jobProcessingEvent->job)
+            ? $this->stickiness->setRecordsModified($connectionCreatedEvent->connection)
+            : $this->stickiness->setRecordsFresh($connectionCreatedEvent->connection);
     }
 }

--- a/src/JobInitializers/JobInitializerInterface.php
+++ b/src/JobInitializers/JobInitializerInterface.php
@@ -3,6 +3,7 @@
 namespace Mpyw\LaravelCachedDatabaseStickiness\JobInitializers;
 
 use Illuminate\Queue\Events\JobProcessing;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated;
 
 /**
  * Interface JobInitializerInterface
@@ -10,9 +11,17 @@ use Illuminate\Queue\Events\JobProcessing;
 interface JobInitializerInterface
 {
     /**
-     * Initialize database stickiness state before processing each job.
+     * Initialize database stickiness state on already resolved connections before processing each job.
      *
      * @param \Illuminate\Queue\Events\JobProcessing $event
      */
-    public function initializeStickinessState(JobProcessing $event): void;
+    public function initializeOnResolvedConnections(JobProcessing $event): void;
+
+    /**
+     * Initialize database stickiness state on newly created connection before processing each job.
+     *
+     * @param \Illuminate\Queue\Events\JobProcessing                         $jobProcessingEvent
+     * @param \Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated $connectionCreatedEvent
+     */
+    public function initializeOnNewConnection(JobProcessing $jobProcessingEvent, ConnectionCreated $connectionCreatedEvent): void;
 }

--- a/src/StickinessEventListener.php
+++ b/src/StickinessEventListener.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Mpyw\LaravelCachedDatabaseStickiness;
+
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\RecordsHaveBeenModified;
+
+class StickinessEventListener
+{
+    /**
+     * @var \Mpyw\LaravelCachedDatabaseStickiness\StickinessManager
+     */
+    protected $stickiness;
+
+    /**
+     * @var null|\Illuminate\Queue\Events\JobProcessing
+     */
+    protected $currentJobProcessingEvent;
+
+    /**
+     * StickinessEventListener constructor.
+     *
+     * @param \Mpyw\LaravelCachedDatabaseStickiness\StickinessManager $stickiness
+     */
+    public function __construct(StickinessManager $stickiness)
+    {
+        $this->stickiness = $stickiness;
+    }
+
+    /**
+     * Called when JobProcessing dispatched.
+     *
+     * @param \Illuminate\Queue\Events\JobProcessing $event
+     */
+    public function onJobProcessing(JobProcessing $event): void
+    {
+        $this->stickiness->initializeStickinessState($this->currentJobProcessingEvent = $event);
+    }
+
+    /**
+     * Called when JobProcessed dispatched.
+     *
+     * @param \Illuminate\Queue\Events\JobProcessed $event
+     */
+    public function onJobProcessed(JobProcessed $event): void
+    {
+        $this->currentJobProcessingEvent = null;
+    }
+
+    /**
+     * Called when JobExceptionOccurred dispatched.
+     *
+     * @param \Illuminate\Queue\Events\JobExceptionOccurred $event
+     */
+    public function onJobExceptionOccurred(JobExceptionOccurred $event): void
+    {
+        $this->currentJobProcessingEvent = null;
+    }
+
+    /**
+     * Called when JobFailed dispatched.
+     *
+     * @param \Illuminate\Queue\Events\JobFailed $event
+     */
+    public function onJobFailed(JobFailed $event): void
+    {
+        $this->currentJobProcessingEvent = null;
+    }
+
+    /**
+     * Called when ConnectionCreated dispatched.
+     *
+     * @param \Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated $event
+     */
+    public function onConnectionCreated(ConnectionCreated $event): void
+    {
+        if ($this->currentJobProcessingEvent) {
+            $this->stickiness->initializeStickinessState($this->currentJobProcessingEvent, $event);
+        }
+
+        $this->stickiness->resolveRecordsModified($event->connection);
+    }
+
+    /**
+     * Called when RecordsHaveBeenModified dispatched.
+     *
+     * @param \Mpyw\LaravelCachedDatabaseStickiness\Events\RecordsHaveBeenModified $event
+     */
+    public function onRecordsHaveBeenModified(RecordsHaveBeenModified $event): void
+    {
+        $this->stickiness->markAsModified($event->connection);
+    }
+}

--- a/tests/Feature/InitializingTest.php
+++ b/tests/Feature/InitializingTest.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Mail;
 use Illuminate\Support\Facades\Notification;
 use Mpyw\LaravelCachedDatabaseStickiness\ConnectionServiceProvider;
 use Mpyw\LaravelCachedDatabaseStickiness\StickinessServiceProvider;
+use Mpyw\LaravelCachedDatabaseStickiness\Tests\Stubs\Jobs\ConnectionResolvableJob;
 use Mpyw\LaravelCachedDatabaseStickiness\Tests\Stubs\Jobs\FreshJob;
 use Mpyw\LaravelCachedDatabaseStickiness\Tests\Stubs\Jobs\GeneralJob;
 use Mpyw\LaravelCachedDatabaseStickiness\Tests\Stubs\Jobs\ModifiedJob;
@@ -123,6 +124,13 @@ class InitializingTest extends TestCase
         $this->assertFalse($this->getRecordsModifiedViaReflection());
 
         Mail::send(new ModifiedMailable());
+
+        $this->assertTrue($this->getRecordsModifiedViaReflection());
+    }
+
+    public function testUnresolvedConnectionShouldBeInitializedAfterJobProcessingDispatched(): void
+    {
+        Bus::dispatch(new ConnectionResolvableJob());
 
         $this->assertTrue($this->getRecordsModifiedViaReflection());
     }

--- a/tests/Stubs/Jobs/ConnectionResolvableJob.php
+++ b/tests/Stubs/Jobs/ConnectionResolvableJob.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Mpyw\LaravelCachedDatabaseStickiness\Tests\Stubs\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Support\Facades\DB;
+
+class ConnectionResolvableJob implements ShouldQueue
+{
+    public function handle(): void
+    {
+        DB::connection();
+    }
+}

--- a/tests/Unit/JobInitializers/AlwaysFreshInitializerTest.php
+++ b/tests/Unit/JobInitializers/AlwaysFreshInitializerTest.php
@@ -7,6 +7,7 @@ use Illuminate\Database\ConnectionInterface;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Queue\Events\JobProcessing;
 use Mockery;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated;
 use Mpyw\LaravelCachedDatabaseStickiness\JobInitializers\AlwaysFreshInitializer;
 use Mpyw\LaravelCachedDatabaseStickiness\StickinessManager;
 use Orchestra\Testbench\TestCase;
@@ -31,7 +32,12 @@ class AlwaysFreshInitializerTest extends TestCase
     /**
      * @var \Illuminate\Queue\Events\JobProcessing
      */
-    protected $event;
+    protected $jobProcessingEvent;
+
+    /**
+     * @var \Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated
+     */
+    protected $connectionCreatedEvent;
 
     /**
      * @var \Illuminate\Contracts\Queue\Job|\Mockery\LegacyMockInterface|\Mockery\MockInterface
@@ -51,7 +57,8 @@ class AlwaysFreshInitializerTest extends TestCase
         $this->db = Mockery::mock(DatabaseManager::class);
         $this->connection = Mockery::mock(ConnectionInterface::class);
         $this->job = Mockery::mock(Job::class);
-        $this->event = new JobProcessing('foo', $this->job);
+        $this->jobProcessingEvent = new JobProcessing('foo', $this->job);
+        $this->connectionCreatedEvent = new ConnectionCreated($this->connection);
 
         $this->initializer = Mockery::mock(AlwaysFreshInitializer::class . '[shouldAssumeModified,shouldAssumeFresh]', [
             $this->stickiness,
@@ -59,30 +66,54 @@ class AlwaysFreshInitializerTest extends TestCase
         ]);
     }
 
-    public function testModifiedJob(): void
+    public function testInitializeOnResolvedConnectionsWithModifiedJob(): void
     {
         $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnTrue();
         $this->db->shouldReceive('getConnections')->once()->andReturn([$this->connection]);
         $this->stickiness->shouldReceive('setRecordsModified')->once()->with($this->connection);
 
-        $this->initializer->initializeStickinessState($this->event);
+        $this->initializer->initializeOnResolvedConnections($this->jobProcessingEvent);
     }
 
-    public function testFreshJob(): void
+    public function testInitializeOnResolvedConnectionsWithFreshJob(): void
     {
         $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnFalse();
         $this->db->shouldReceive('getConnections')->once()->andReturn([$this->connection]);
         $this->stickiness->shouldReceive('setRecordsFresh')->once()->with($this->connection);
 
-        $this->initializer->initializeStickinessState($this->event);
+        $this->initializer->initializeOnResolvedConnections($this->jobProcessingEvent);
     }
 
-    public function testGeneralJob(): void
+    public function testInitializeOnResolvedConnectionsWithGeneralJob(): void
     {
         $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnNull();
         $this->db->shouldReceive('getConnections')->once()->andReturn([$this->connection]);
         $this->stickiness->shouldReceive('setRecordsFresh')->once()->with($this->connection);
 
-        $this->initializer->initializeStickinessState($this->event);
+        $this->initializer->initializeOnResolvedConnections($this->jobProcessingEvent);
+    }
+
+    public function testInitializeOnNewConnectionWithModifiedJob(): void
+    {
+        $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnTrue();
+        $this->stickiness->shouldReceive('setRecordsModified')->once()->with($this->connection);
+
+        $this->initializer->initializeOnNewConnection($this->jobProcessingEvent, $this->connectionCreatedEvent);
+    }
+
+    public function testInitializeOnNewConnectionWithFreshJob(): void
+    {
+        $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnFalse();
+        $this->stickiness->shouldReceive('setRecordsFresh')->once()->with($this->connection);
+
+        $this->initializer->initializeOnNewConnection($this->jobProcessingEvent, $this->connectionCreatedEvent);
+    }
+
+    public function testInitializeOnNewConnectionWithGeneralJob(): void
+    {
+        $this->initializer->shouldReceive('shouldAssumeModified')->once()->with($this->job)->andReturnNull();
+        $this->stickiness->shouldReceive('setRecordsFresh')->once()->with($this->connection);
+
+        $this->initializer->initializeOnNewConnection($this->jobProcessingEvent, $this->connectionCreatedEvent);
     }
 }

--- a/tests/Unit/StickinessEventListenerTest.php
+++ b/tests/Unit/StickinessEventListenerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace Mpyw\LaravelCachedDatabaseStickiness\Tests\Unit;
+
+use Illuminate\Contracts\Queue\Job;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Queue\Events\JobExceptionOccurred;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Mockery;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\ConnectionCreated;
+use Mpyw\LaravelCachedDatabaseStickiness\Events\RecordsHaveBeenModified;
+use Mpyw\LaravelCachedDatabaseStickiness\StickinessEventListener;
+use Mpyw\LaravelCachedDatabaseStickiness\StickinessManager;
+use Orchestra\Testbench\TestCase;
+use ReflectionProperty;
+
+class StickinessEventListenerTest extends TestCase
+{
+    /**
+     * @var \Mockery\LegacyMockInterface|\Mockery\MockInterface|\Mpyw\LaravelCachedDatabaseStickiness\StickinessManager
+     */
+    protected $stickiness;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->stickiness = Mockery::mock(StickinessManager::class);
+    }
+
+    protected function setCurrentJobProcessingEvent(StickinessEventListener $listener, ?JobProcessing $event): void
+    {
+        /* @noinspection PhpUnhandledExceptionInspection */
+        $property = new ReflectionProperty($listener, 'currentJobProcessingEvent');
+        $property->setAccessible(true);
+        $property->setValue($listener, $event);
+    }
+
+    protected function getCurrentJobProcessingEvent(StickinessEventListener $listener): ?JobProcessing
+    {
+        /* @noinspection PhpUnhandledExceptionInspection */
+        $property = new ReflectionProperty($listener, 'currentJobProcessingEvent');
+        $property->setAccessible(true);
+        return $property->getValue($listener);
+    }
+
+    public function testOnJobProcessing(): void
+    {
+        $event = Mockery::mock(JobProcessing::class);
+
+        $this->stickiness->shouldReceive('initializeStickinessState')->once()->with($event);
+
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->assertNull($this->getCurrentJobProcessingEvent($listener));
+
+        $listener->onJobProcessing($event);
+
+        $this->assertSame($event, $this->getCurrentJobProcessingEvent($listener));
+    }
+
+    public function testOnJobProcessed(): void
+    {
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->setCurrentJobProcessingEvent($listener, $event = Mockery::mock(JobProcessing::class));
+
+        $listener->onJobProcessed(Mockery::mock(JobProcessed::class));
+
+        $this->assertNull($this->getCurrentJobProcessingEvent($listener));
+    }
+
+    public function testOnJobExceptionOccurred(): void
+    {
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->setCurrentJobProcessingEvent($listener, $event = Mockery::mock(JobProcessing::class));
+
+        $listener->onJobExceptionOccurred(Mockery::mock(JobExceptionOccurred::class));
+
+        $this->assertNull($this->getCurrentJobProcessingEvent($listener));
+    }
+
+    public function testOnJobFailed(): void
+    {
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->setCurrentJobProcessingEvent($listener, $event = Mockery::mock(JobProcessing::class));
+
+        $listener->onJobFailed(Mockery::mock(JobFailed::class));
+
+        $this->assertNull($this->getCurrentJobProcessingEvent($listener));
+    }
+
+    public function onConnectionCreatedWithCurrentJobProcessingEvent(): void
+    {
+        $job = Mockery::mock(Job::class);
+        $connection = Mockery::mock(Connection::class);
+
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->setCurrentJobProcessingEvent($listener, $event = new JobProcessing('foo', $job));
+
+        $this->stickiness->shouldReceive('initializeStickinessState')->once()->with($event);
+        $this->stickiness->shouldReceive('resolveRecordsModified')->once();
+
+        $listener->onConnectionCreated(new ConnectionCreated($connection));
+    }
+
+    public function onConnectionCreatedWithoutCurrentJobProcessingEvent(): void
+    {
+        $connection = Mockery::mock(Connection::class);
+
+        $listener = new StickinessEventListener($this->stickiness);
+
+        $this->setCurrentJobProcessingEvent($listener, null);
+
+        $this->stickiness->shouldNotReceive('initializeStickinessState');
+        $this->stickiness->shouldReceive('resolveRecordsModified')->once();
+
+        $listener->onConnectionCreated(new ConnectionCreated($connection));
+    }
+
+    public function testOnRecordsHaveBeenModified(): void
+    {
+        $connection = Mockery::mock(ConnectionInterface::class);
+
+        $this->stickiness->shouldReceive('markAsModified')->once()->with($connection);
+
+        $listener = new StickinessEventListener($this->stickiness);
+        $listener->onRecordsHaveBeenModified(new RecordsHaveBeenModified($connection));
+    }
+}


### PR DESCRIPTION
Fixes #3.

```php
class ConnectionResolvableJob implements ShouldQueue, ShouldAssumeFresh
{
    public function handle(): void
    {
        DB::connection();
    }
}
```

Now `ShouldAssumeFresh` will correctly work even if the connection is not yet resolved.