### PR TITLE
Fix: Change ServiceProvider lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ use Illuminate\Support\ServiceProvider;
 
 class DatabaseServiceProvider extends ServiceProvider
 {
-    public function boot(): void
+    public function register(): void
     {
         Connection::resolverFor('mysql', function (...$parameters) {
             return new MySqlConnection(...$parameters);

--- a/src/ConnectionServiceProvider.php
+++ b/src/ConnectionServiceProvider.php
@@ -15,7 +15,7 @@ class ConnectionServiceProvider extends ServiceProvider
     /**
      * {@inheritdoc}
      */
-    public function boot(): void
+    public function register(): void
     {
         Connection::resolverFor('mysql', $this->resolverFor(MySqlConnection::class));
         Connection::resolverFor('pgsql', $this->resolverFor(PostgresConnection::class));


### PR DESCRIPTION
`Connection::resolverFor()` does not touch the container.