### PR TITLE
Fix: Ignore cache when sticky configuration is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ return [
                 'host' => env('DB_HOST_READONLY'),
             ] : null,
             'write' => [],
-            'sticky' => true,
+            'sticky' => (bool)env('DB_HOST_READONLY'),
             'stickiness_ttl' => 3, // Set the stickiness TTL to 3 seconds
             'driver' => 'mysql',
             'host' => env('DB_HOST', '127.0.0.1'),

--- a/src/StickinessEventListener.php
+++ b/src/StickinessEventListener.php
@@ -91,7 +91,9 @@ class StickinessEventListener
             $this->currentJobInitialization->initializeOnNewConnection($this->currentJobProcessingEvent, $event);
         }
 
-        $this->stickiness->resolveRecordsModified($event->connection);
+        if ($event->connection->getConfig('sticky')) {
+            $this->stickiness->resolveRecordsModified($event->connection);
+        }
     }
 
     /**
@@ -105,6 +107,8 @@ class StickinessEventListener
             $this->currentJobInitialization->dontRevokeEffectsOn($event->connection);
         }
 
-        $this->stickiness->markAsModified($event->connection);
+        if ($event->connection->getConfig('sticky')) {
+            $this->stickiness->markAsModified($event->connection);
+        }
     }
 }


### PR DESCRIPTION
## Overview

In past, this package always triggered cache accesses regardless of the `sticky` configuration. However, `Connection::$recordsHaveBeenModified` will never change if `sticky` is false. This PR prevents it from uselessly accessing a cache storage.
