### PR TITLE
Fix: Prevent ServiceProvider from overwriting bindings

### DIFF
--- a/src/StickinessServiceProvider.php
+++ b/src/StickinessServiceProvider.php
@@ -42,7 +42,7 @@ class StickinessServiceProvider extends ServiceProvider
         $this->app->singleton(StickinessEventListener::class);
         $this->app->singleton('db.factory', ConnectionFactory::class);
 
-        $this->app->bind(StickinessResolverInterface::class, IpBasedResolver::class);
-        $this->app->bind(JobInitializerInterface::class, AlwaysModifiedInitializer::class);
+        $this->app->bindIf(StickinessResolverInterface::class, IpBasedResolver::class);
+        $this->app->bindIf(JobInitializerInterface::class, AlwaysModifiedInitializer::class);
     }
 }


### PR DESCRIPTION
Third party package providers whose name starts with a letter before `M`(pyw) in alphabetical order are overwritten so far. If implementations of interfaces are already bound, we must not overwrite them. 

We need to use `bindIf` instead of `bind`.

```php
    /**
     * Register a binding if it hasn't already been registered.
     *
     * @param  string  $abstract
     * @param  \Closure|string|null  $concrete
     * @param  bool  $shared
     * @return void
     */
    public function bindIf($abstract, $concrete = null, $shared = false)
    {
        if (! $this->bound($abstract)) {
            $this->bind($abstract, $concrete, $shared);
        }
    }

```